### PR TITLE
Feature/point add

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,4 @@
 //= require_tree .
 //= require_self
+//= require rails-ujs
+//= require turbolinks

--- a/app/assets/stylesheets/output.css
+++ b/app/assets/stylesheets/output.css
@@ -909,6 +909,10 @@ select {
   margin-right: 2rem;
 }
 
+.mt-12 {
+  margin-top: 3rem;
+}
+
 .mt-2 {
   margin-top: 0.5rem;
 }
@@ -927,10 +931,6 @@ select {
 
 .mt-8 {
   margin-top: 2rem;
-}
-
-.mt-12 {
-  margin-top: 3rem;
 }
 
 .block {
@@ -1440,6 +1440,11 @@ select {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.text-red-100 {
+  --tw-text-opacity: 1;
+  color: rgb(255 127 127 / var(--tw-text-opacity, 1));
 }
 
 .underline {

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -3,7 +3,7 @@ class QuestionsController < ApplicationController
         @quiz = Quiz.find(params[:quiz_id])
         @questions = @quiz.questions.includes(:choices)
         @user = current_user
-        @current_score = @user.current_score if @user
+        @current_score = @user.total_points if @user
     end
 
     def destroy

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -30,13 +30,19 @@ class QuestionsController < ApplicationController
     end
 
     def destroy
-        @quiz = Quiz.find(params[:quiz_id])
-        @question = @quiz.questions.find(params[:id])
+        @question = Question.find(params[:id])
+        quiz = @question.quiz # 削除する設問が属するクイズを取得
 
         if @question.destroy
-            render json: { message: '設問が削除されました。' }, status: :ok
+            # 削除後にクイズ内の設問が残っているか確認
+            if quiz.questions.count == 0
+                quiz.destroy # 設問が残っていなければクイズを削除
+                redirect_to quizzes_path, notice: 'クイズが削除されました！'
+            else
+                redirect_to quizzes_path, notice: '質問が削除されました！'
+            end
         else
-            render json: { error: '設問の削除に失敗しました。' }, status: :unprocessable_entity
+            redirect_to quizzes_path, alert: '質問の削除に失敗しました。'
         end
     end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -2,6 +2,8 @@ class QuestionsController < ApplicationController
     def index
         @quiz = Quiz.find(params[:quiz_id])
         @questions = @quiz.questions.includes(:choices)
+        @user = current_user
+        @current_score = @user.current_score if @user
     end
 
     def destroy

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -29,6 +29,11 @@ class QuestionsController < ApplicationController
         render 'answer'
     end
 
+    def confirm_destroy
+        @question = Question.find(params[:id])
+        @quiz = @question.quiz # 削除する設問が属するクイズを取得
+    end
+
     def destroy
         @question = Question.find(params[:id])
         quiz = @question.quiz # 削除する設問が属するクイズを取得

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,6 +4,29 @@ class QuestionsController < ApplicationController
         @questions = @quiz.questions.includes(:choices)
         @user = current_user
         @current_score = @user.total_points if @user
+
+        # 特定の設問を表示するためのロジックを追加
+        if params[:question_id]
+            @current_question = Question.find(params[:question_id])
+        end
+    end
+
+
+    def answer
+        @question = Question.find(params[:id])
+        @user = current_user # ユーザー情報を取得
+
+        # ユーザーの回答を取得
+        @user_question = UserQuestion.where(user_id: @user.id, question_id: @question.id).order(created_at: :desc).first
+
+        @user_answer = @user_question.result # user_questionsテーブルのresultカラムの値を取得
+
+        @explanation = @question.supplement # 質問の解説を取得
+        Rails.logger.debug("User Questionだよ: #{@user_question}")
+        Rails.logger.debug("User Answerだよ: #{@user_question.result}")
+
+        # answer.html.erb ビューを表示
+        render 'answer'
     end
 
     def destroy
@@ -26,6 +49,42 @@ class QuestionsController < ApplicationController
         else
             render json: { error: '設問の更新に失敗しました。' }, status: :unprocessable_entity
         end
+    end
+
+    def show
+        @question = Question.find(params[:id]) # ここで質問を取得
+        @user = current_user # ユーザー情報を取得
+        @quiz = Quiz.find(params[:quiz_id])
+        @questions = @quiz.questions.includes(:choices)
+        @current_score = @user.total_points if @user
+        @quiz_questions = @question.quiz.questions
+        @question_index = @quiz_questions.index(@question) + 1 # 1から始まる番号にするために +1
+
+        # 特定の設問を表示するためのロジックを追加
+        if params[:question_id]
+            @current_question = Question.find(params[:question_id])
+        end
+    end
+
+    def result
+        @quiz = Quiz.find(params[:quiz_id])
+        @user = current_user
+
+        @user_questions = UserQuestion.where(user_id: @user.id, question_id: @quiz.questions.pluck(:id))
+                                      .order(created_at: :desc)
+                                      .limit(@quiz.questions.count)
+
+        # resultがtrueのものの数をカウント
+        @correct_answers = @user_questions.select(:result).count { |uq| uq.result == true }
+
+        # 総設問数を取得
+        @total_questions = @quiz.questions.count
+
+        Rails.logger.debug("User Questions: #{@user_questions.inspect}")
+        Rails.logger.debug("Correct Answers Count: #{@correct_answers_count}")
+
+        # 最初の設問を取得
+        @first_question = @quiz.questions.first
     end
 
     private

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -71,8 +71,15 @@ class QuizzesController < ApplicationController
     end
 
     def destroy
-        @quiz = Quiz.find(params[:id])
-        @quiz.update(deleted_at: Time.current)
-        redirect_to quizzes_path, notice: 'クイズが削除されました！'
+        @quiz = Quiz.includes(questions: :choices).find(params[:id]) # 関連する設問と選択肢を含めて取得
+        Rails.logger.debug("Deleting quiz: #{@quiz.inspect}")
+        if @quiz.destroy
+            Rails.logger.debug("Quiz deleted successfully")
+            redirect_to quizzes_path, notice: 'クイズが削除されました！'
+        else
+            Rails.logger.debug("Failed to delete quiz")
+            redirect_to quizzes_path, alert: 'クイズの削除に失敗しました。'
+        end
     end
+
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -34,26 +34,6 @@ class QuizzesController < ApplicationController
         end
     end
 
-    def quiz_params
-    params.require(:quiz).permit(
-    :title,
-    :description,
-    :image,
-    questions_attributes: [
-        :id,
-        :content,
-        :supplement,
-        :_destroy,
-        choices_attributes: [
-        :id,
-        :name,
-        :is_valid,
-        :_destroy
-        ]
-    ]
-    )
-    end
-
 
     def edit
         @quiz = Quiz.find(params[:id])
@@ -80,6 +60,30 @@ class QuizzesController < ApplicationController
             Rails.logger.debug("Failed to delete quiz")
             redirect_to quizzes_path, alert: 'クイズの削除に失敗しました。'
         end
+    end
+
+    def confirm_destroy
+        @quiz = Quiz.find(params[:id])
+    end
+
+    def quiz_params
+        params.require(:quiz).permit(
+        :title,
+        :description,
+        :image,
+        questions_attributes: [
+            :id,
+            :content,
+            :supplement,
+            :_destroy,
+            choices_attributes: [
+            :id,
+            :name,
+            :is_valid,
+            :_destroy
+            ]
+        ]
+        )
     end
 
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -10,7 +10,8 @@ class QuizzesController < ApplicationController
 
     def overview
         @quiz = Quiz.find(params[:id])
-        @is_owner = @quiz.user_id == current_user.id
+        @first_question = @quiz.questions.first # 最初の設問を取得
+        @is_owner = current_user == @quiz.user # クイズのオーナーかどうかを判定
     end
 
     def show

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,8 +1,9 @@
 class QuizzesController < ApplicationController
     def index
         @quizzes = Quiz.all
+        @user = current_user # 現在のユーザーを取得
+        @current_score = @user.total_points if @user # ユーザーが存在する場合にポイントを計算
         Rails.logger.debug("session[:userinfo]: #{session[:userinfo].inspect}")
-        @user = session[:userinfo]
         @users = User.all
     end
     include Secured

--- a/app/controllers/user_questions_controller.rb
+++ b/app/controllers/user_questions_controller.rb
@@ -1,19 +1,19 @@
 class UserQuestionsController < ApplicationController
   def create
-    user_question = UserQuestion.new(user_question_params)
+    @user_question = UserQuestion.new(user_question_params)
 
     # ユーザーがすでに質問に回答したかどうかを確認
-    if UserQuestion.where(user_id: user_question.user_id, question_id: user_question.question_id).exists?
-      user_question.is_first = false # 2回目以降はis_firstをfalseに設定
+    if UserQuestion.where(user_id: @user_question.user_id, question_id: @user_question.question_id).exists?
+      @user_question.is_first = false # 2回目以降はis_firstをfalseに設定
     else
-      user_question.is_first = true # 1回目はis_firstをtrueに設定
+      @user_question.is_first = true # 1回目はis_firstをtrueに設定
     end
 
-    if user_question.save
-      render json: { status: 'success', user_question: user_question }, status: :created
+    if @user_question.save
+      redirect_to answer_quiz_question_path(@user_question.question.quiz_id, @user_question.question.id), notice: '回答が保存されました。'
     else
-      Rails.logger.error(user_question.errors.full_messages) # エラーメッセージをログに出力
-      render json: { status: 'error', errors: user_question.errors.full_messages }, status: :unprocessable_entity
+      Rails.logger.error(@user_question.errors.full_messages) # エラーメッセージをログに出力
+      render :new
     end
   end
 

--- a/app/controllers/user_questions_controller.rb
+++ b/app/controllers/user_questions_controller.rb
@@ -1,0 +1,27 @@
+class UserQuestionsController < ApplicationController
+  def create
+    user_question = UserQuestion.new(user_question_params)
+
+    if user_question.save
+      render json: { status: 'success', user_question: user_question }, status: :created
+    else
+      Rails.logger.error(user_question.errors.full_messages) # エラーメッセージをログに出力
+      render json: { status: 'error', errors: user_question.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def current_score
+    user_id = current_user.id # 現在のユーザーのIDを取得
+    score = UserQuestion.joins(question: :point)
+                        .where(user_id: user_id)
+                        .sum('points.point') # pointsテーブルのvalueカラムを合計
+
+    render json: { score: score }
+  end
+
+  private
+
+  def user_question_params
+    params.require(:user_question).permit(:user_id, :question_id, :result, :is_first)
+  end
+end

--- a/app/controllers/user_questions_controller.rb
+++ b/app/controllers/user_questions_controller.rb
@@ -2,6 +2,13 @@ class UserQuestionsController < ApplicationController
   def create
     user_question = UserQuestion.new(user_question_params)
 
+    # ユーザーがすでに質問に回答したかどうかを確認
+    if UserQuestion.where(user_id: user_question.user_id, question_id: user_question.question_id).exists?
+      user_question.is_first = false # 2回目以降はis_firstをfalseに設定
+    else
+      user_question.is_first = true # 1回目はis_firstをtrueに設定
+    end
+
     if user_question.save
       render json: { status: 'success', user_question: user_question }, status: :created
     else

--- a/app/helpers/user_questions_helper.rb
+++ b/app/helpers/user_questions_helper.rb
@@ -1,0 +1,2 @@
+module UserQuestionsHelper
+end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -1,2 +1,3 @@
 class Point < ApplicationRecord
+    has_many :questions
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,6 @@
 class Question < ApplicationRecord
     has_many :choices, dependent: :destroy
     belongs_to :quiz
+    belongs_to :point, optional: true
     accepts_nested_attributes_for :choices, allow_destroy: true
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,4 +3,5 @@ class Question < ApplicationRecord
     belongs_to :quiz
     belongs_to :point, optional: true
     accepts_nested_attributes_for :choices, allow_destroy: true
+    has_many :user_questions
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,9 @@
 class User < ApplicationRecord
     has_many :quizzes
+
+    def current_score
+        UserQuestion.joins(question: :point)
+                    .where(user_id: id)
+                    .sum('points.point') # pointsテーブルのvalueカラムを合計
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,9 @@
 class User < ApplicationRecord
     has_many :quizzes
 
-    def current_score
+    def total_points
         UserQuestion.joins(question: :point)
-                    .where(user_id: id)
-                    .sum('points.point') # pointsテーブルのvalueカラムを合計
+                    .where(user_id: id, result: true, is_first: true)
+                    .sum('points.point') # pointsテーブルのpointカラムを合計
     end
 end

--- a/app/models/user_question.rb
+++ b/app/models/user_question.rb
@@ -1,2 +1,4 @@
 class UserQuestion < ApplicationRecord
+    belongs_to :user
+    belongs_to :question
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "data-turbo-track": "reload" %>
     <%= javascript_include_tag 'quiz', 'quiz_create' %>
   </head>
 

--- a/app/views/questions/answer.html.erb
+++ b/app/views/questions/answer.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>解説</title>
+</head>
+<body>
+    <h1>質問: <%= @question.content %></h1>
+    <p>あなたの回答: <%= @user_answer == true ? '正解' : '不正解' %></p>
+    <% if @user_answer == true %>
+        <p>おめでとうございます！正解です。</p>
+    <% else %>
+        <p>残念ながら不正解です。もう一度挑戦してください。</p>
+    <% end %>
+    <h2>解説</h2>
+    <p><%= @explanation %></p>
+
+    <% next_question = @question.quiz.questions.where("id > ?", @question.id).first %>
+    <% if next_question %>
+        <%= link_to '次の質問へ', quiz_question_path(@question.quiz_id, next_question.id), class: 'btn btn-primary' %>
+    <% else %>
+        <p>これが最後の質問です。</p>
+        <%= link_to '結果を確認する', result_quiz_question_path(@question.quiz_id), class: 'btn btn-primary' %>
+    <% end %>
+</body>
+</html>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -36,17 +36,17 @@
                     <% end %>
                     <div class="w-full my-8 flex justify-center gap-4">
                         <% question.choices.each do |choice| %>
-                        <%= form_with url: user_questions_path, method: :post, local: true do %>
-                            <p class="choice w-1/3 bg-gray-100 p-4 text-center flex items-center font-bold border-4 rounded-lg border-gray-200 cursor-pointer"
-                                data-is-valid="<%= choice.is_valid %>">
-                                <%= choice.name %>
-                            </p>
-                            <%= hidden_field_tag "user_question[user_id]", @user['id'] %>
-                            <%= hidden_field_tag "user_question[question_id]", question.id %>
-                            <%= hidden_field_tag "user_question[result]",  choice.is_valid %>
-                            <%= hidden_field_tag "user_question[is_first]", false %>
-                            <%= submit_tag "送信", class: "btn btn-primary" %>
-                        <% end %>
+                            <%= form_with url: answer_quiz_question_path(question.quiz_id, question.id), method: :post, local: true do %>
+                                <p class="choice w-1/3 bg-gray-100 p-4 text-center flex items-center font-bold border-4 rounded-lg border-gray-200 cursor-pointer hidden"
+                                    data-is-valid="<%= choice.is_valid %>">
+                                    <%= choice.name %>
+                                </p>
+                                <%= hidden_field_tag "user_question[user_id]", @user['id'] %>
+                                <%= hidden_field_tag "user_question[question_id]", question.id %>
+                                <%= hidden_field_tag "user_question[result]",  choice.is_valid %>
+                                <%= hidden_field_tag "user_question[is_first]", false %>
+                                <%= submit_tag choice.name, class: "btn btn-primary" %>
+                            <% end %>
                         <% end %>
                     </div>
                     <div class="correct hidden">

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -27,18 +27,26 @@
             <% @questions.each_with_index do |question, index| %>
                 <div class="w-full mb-32" data-quiz-id="<%= question.id %>">
                     <p class="bg-[#0071bc] rounded-lg text-white text-3xl w-20 h-16 font-bold mb-6 flex justify-center items-center">Q<%= index + 1 %></p>
+                    <p class="text-xl font-bold mt-4">ポイント: <%= question.point.point %> pt</p>
                     <p class="text-3xl font-bold leading-normal"><%= question.content %></p>
-                    <% if question.image.present? && question.image.attached? %>
-                    <%= image_tag question.image, alt: "milmil", class: "w-1/5" %>
+                    <% if question.image.is_a?(ActiveStorage::Attached::One) && question.image.attached? %>
+                        <%= image_tag question.image, alt: "milmil", class: "w-1/5" %>
                     <% else %>
-                    <%= image_tag 'quiz02.png', alt: 'default image', class: 'w-1/5' %> <!-- デフォルト画像 -->
+                        <%= image_tag 'quiz02.png', alt: 'default image', class: 'w-1/5' %> <!-- デフォルト画像 -->
                     <% end %>
                     <div class="w-full my-8 flex justify-center gap-4">
                         <% question.choices.each do |choice| %>
-                        <p class="choice w-1/3 bg-gray-100 p-4 text-center flex items-center font-bold border-4 rounded-lg border-gray-200 cursor-pointer"
-                            data-is-valid="<%= choice.is_valid %>">
-                            <%= choice.name %>
-                        </p>
+                        <%= form_with url: user_questions_path, method: :post, local: true do %>
+                            <p class="choice w-1/3 bg-gray-100 p-4 text-center flex items-center font-bold border-4 rounded-lg border-gray-200 cursor-pointer"
+                                data-is-valid="<%= choice.is_valid %>">
+                                <%= choice.name %>
+                            </p>
+                            <%= hidden_field_tag "user_question[user_id]", @user['id'] %>
+                            <%= hidden_field_tag "user_question[question_id]", question.id %>
+                            <%= hidden_field_tag "user_question[result]",  choice.is_valid %>
+                            <%= hidden_field_tag "user_question[is_first]", false %>
+                            <%= submit_tag "送信", class: "btn btn-primary" %>
+                        <% end %>
                         <% end %>
                     </div>
                     <div class="correct hidden">
@@ -73,7 +81,7 @@
                         </p>
                         <% end %>
                     </div>
-  
+
                 </div>
             <% end %>
         </div>

--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>結果</title>
+</head>
+<body>
+    <h1>結果</h1>
+    <p>あなたの正解数: <%= @correct_answers %> / <%= @total_questions %></p>
+    <% if @correct_answers == @total_questions %>
+        <p>素晴らしい！全問正解です！</p>
+    <% else %>
+        <p>次回はもっと頑張りましょう！</p>
+    <% end %>
+    <%= link_to '再挑戦する', quiz_question_path(@quiz, @first_question), class: 'btn btn-primary' %>
+    <%= link_to "トップに戻る", quizzes_path, class: "ml-4 text-blue-500 hover:underline" %>
+</body>
+</html> 

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= @question.content %></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+</head>
+
+<body class="font-noto">
+
+    <div class="bg-[url('bg-hero.png')] bg-center bg-contain bg-no-repeat text-white font-bold pt-40 pb-10">
+        <div class="ml-10">
+            <p class="text-lg mx-auto">
+                POSSE課題
+            </p>
+            <p class="text-6xl mt-3 mb-40">
+                ITクイズ
+            </p>
+        </div>
+    </div>
+    <main class="w-5/6 mx-auto">
+        <div id="quiz-container">
+            <% if @question.present? %>
+                <div class="w-full mb-32" data-quiz-id="<%= @question.id %>">
+                    <p class="bg-[#0071bc] rounded-lg text-white text-3xl w-20 h-16 font-bold mb-6 flex justify-center items-center">Q<%= @question_index %></p>
+                    <p class="text-xl font-bold mt-4">ポイント: <%= @question.point.point %> pt</p>
+                    <p class="text-3xl font-bold leading-normal"><%= @question.content %></p>
+                    <% if @question.image.is_a?(ActiveStorage::Attached::One) && @question.image.attached? %>
+                        <%= image_tag @question.image, alt: "milmil", class: "w-1/5" %>
+                    <% else %>
+                        <%= image_tag 'quiz02.png', alt: 'default image', class: 'w-1/5' %> <!-- デフォルト画像 -->
+                    <% end %>
+                    <div class="w-full my-8 flex justify-center gap-4">
+                        <% @question.choices.each do |choice| %>
+                            <%= form_with url: user_questions_path, method: :post, local: true do %>
+                                <p class="choice w-1/3 bg-gray-100 p-4 text-center flex items-center font-bold border-4 rounded-lg border-gray-200 cursor-pointer hidden"
+                                    data-is-valid="<%= choice.is_valid %>">
+                                    <%= choice.name %>
+                                </p>
+                                <%= hidden_field_tag "user_question[user_id]", @user['id'] %>
+                                <%= hidden_field_tag "user_question[question_id]", @question.id %>
+                                <%= hidden_field_tag "user_question[result]", choice.is_valid %>
+                                <%= hidden_field_tag "user_question[is_first]", false %>
+                                <%= submit_tag choice.name, class: "btn btn-primary" %>
+                            <% end %>
+                        <% end %>
+                    </div>
+                    <% if @question.supplement.present? %>
+                        <p class="flex items-center rounded-2xl bg-gray-200 w-full h-20 bg-no-repeat pl-8 font-bold text-lg bg-bottom-[50%] gap-4 mt-2">
+                            <%= image_tag "icon-note.png", class: "w-6 py-8" %>
+                            <%= @question.supplement %>
+                        </p>
+                    <% end %>
+                </div>
+            <% else %>
+                <p>質問が見つかりませんでした。</p>
+            <% end %>
+        </div>
+    </main>
+    <footer class="mx-auto">
+        <%= image_tag "logo.png", class: "mx-auto" %>
+        <div class="text-center mt-6">
+            <a href="">POSSE公式サイト</a>
+        </div>
+        <ul class="flex justify-center mt-4">
+            <li class="w-12 h-12 ml-5 rounded-full bg-white shadow-xs border flex justify-center items-center">
+                <a href="https://twitter.com/posse_program">
+                    <%= image_tag "icon-twitter.png", class: "w-6 h-5" %>
+                </a>
+            </li>
+            <li class="w-12 h-12 ml-4 mr-5 rounded-full bg-white shadow-xs border flex justify-center items-center">
+                <a href="https://www.instagram.com/posse_programming/">
+                    <%= image_tag "icon-instagram.png", class: "w-6 h-6" %>
+                </a>
+            </li>
+        </ul>
+        <div class="text-center mb-8">
+            <small>©︎2024 POSSE</small>
+        </div>
+    </footer>
+</body>
+
+</html> 

--- a/app/views/quizzes/confirm_destroy.html.erb
+++ b/app/views/quizzes/confirm_destroy.html.erb
@@ -63,5 +63,5 @@
     </div>
 
 <% end %>
-<%= link_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
+<%= button_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
 <%= link_to "戻る", quizzes_path, class: "text-blue-500 hover:underline" %>

--- a/app/views/quizzes/confirm_destroy.html.erb
+++ b/app/views/quizzes/confirm_destroy.html.erb
@@ -46,19 +46,22 @@
                             </div>
                         <% end %>
                     </div>
-
                     <%= question_form.text_area :supplement, value: question_form.object.supplement, class: "w-full p-3 border rounded-lg mt-4", rows: 3, placeholder: "解説を入力" %>
                     <input type="hidden" name="quiz[questions_attributes][#{question_form.index}][_destroy]" value="false">
-  
+                    <% if @quiz.questions.count == 1 %>
+                        <div class="mt-2">
+                            <%= button_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
+                        </div>
+                    <% else %>
+                        <div class="mt-2">
+                            <%= button_to "設問を削除", [@quiz, question_form.object], method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:text-red-700" %>
+                        </div>
+                    <% end %>
                 </div>
             <% end %>
         </div>
-        <button type="button" class="bg-green-500 text-white py-2 px-4 rounded-lg hover:bg-green-600" id="add-question">質問を追加</button>
     </div>
 
-    <div class="mb-6 text-center">
-        <%= form.submit "クイズを更新", class: "bg-blue-500 text-block py-2 px-6 rounded-lg hover:bg-blue-600" %>
-    </div>
 <% end %>
 <%= link_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
 <%= link_to "戻る", quizzes_path, class: "text-blue-500 hover:underline" %>

--- a/app/views/quizzes/edit.html.erb
+++ b/app/views/quizzes/edit.html.erb
@@ -49,7 +49,12 @@
 
                 <%= question_form.text_area :supplement, value: question_form.object.supplement, class: "w-full p-3 border rounded-lg mt-4", rows: 3, placeholder: "解説を入力" %>
                 <input type="hidden" name="quiz[questions_attributes][#{question_form.index}][_destroy]" value="false">
-                <button type="button" class="remove-question text-red-500 hover:text-red-700 mt-2">削除</button>
+
+                <% if @quiz.questions.count == 1 %>
+                    <%= button_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
+                <% else %>
+                    <%= button_to "設問を削除", [@quiz, question_form.object], method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:text-red-700 mt-2" %>
+                <% end %>
             </div>
         <% end %>
     </div>
@@ -61,56 +66,4 @@
 </div>
 <% end %>
 
-<%= link_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
 <%= link_to "戻る", quizzes_path, class: "text-blue-500 hover:underline" %>
-
-<script>
-document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll('.remove-question').forEach(button => {
-        button.addEventListener('click', function () {
-            const questionId = this.dataset.questionId;
-            const quizId = "<%= @quiz.id %>";
-            if (confirm("本当に削除しますか？")) {
-                fetch(`/quizzes/${quizId}/questions/${questionId}`, {
-                    method: 'DELETE',
-                    headers: {
-                        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-                    }
-                }).then(response => {
-                    if (response.ok) {
-                        // 成功した場合、設問をDOMから削除
-                        this.closest('.question-fields').remove();
-                    } else {
-                        alert('削除に失敗しました。');
-                    }
-                });
-            }
-        });
-    });
-
-    document.querySelectorAll('.correct-choice').forEach(radio => {
-        radio.addEventListener('change', function () {
-            const questionIndex = this.closest('.question-fields').querySelector('input[type="hidden"]').value;
-
-            // すべての選択肢のis_validをfalseに設定
-            const allChoiceRadios = document.querySelectorAll(`input[name="questions_attributes[${questionIndex}][correct_choice]"]`);
-            allChoiceRadios.forEach(radio => {
-                const hiddenInput = radio.closest('.choice-fields').querySelector('input[type="hidden"]');
-                if (hiddenInput) {
-                    hiddenInput.value = "false";
-                }
-            });
-
-            // 正解に選ばれた選択肢のis_validをtrueに設定
-            const selectedChoiceId = this.value;
-            const correctChoiceField = document.querySelector(`input[value="${selectedChoiceId}"]`);
-            if (correctChoiceField) {
-                const hiddenInput = correctChoiceField.closest('.choice-fields').querySelector('input[type="hidden"]');
-                if (hiddenInput) {
-                    hiddenInput.value = "true";
-                }
-            }
-        });
-    });
-});
-</script>

--- a/app/views/quizzes/edit.html.erb
+++ b/app/views/quizzes/edit.html.erb
@@ -49,7 +49,6 @@
 
                     <%= question_form.text_area :supplement, value: question_form.object.supplement, class: "w-full p-3 border rounded-lg mt-4", rows: 3, placeholder: "解説を入力" %>
                     <input type="hidden" name="quiz[questions_attributes][#{question_form.index}][_destroy]" value="false">
-  
                 </div>
             <% end %>
         </div>
@@ -60,5 +59,4 @@
         <%= form.submit "クイズを更新", class: "bg-blue-500 text-block py-2 px-6 rounded-lg hover:bg-blue-600" %>
     </div>
 <% end %>
-<%= link_to "クイズを削除", quiz_path(@quiz), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-red-500 hover:underline" %>
 <%= link_to "戻る", quizzes_path, class: "text-blue-500 hover:underline" %>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -27,10 +27,12 @@
 <%# <%= JSON.pretty_generate(@user) %>
 
 <div>
+  <input type="hidden" id="current-user-id" value="<%= @user['id'] %>"> <!-- ユーザーIDを隠しフィールドに追加 -->
   <p>User Name: <%= @user["name"] %></p>
   <p>User Email: <%= @user["email"] %></p>
   <p>User Nickname: <%= @user["nickname"] %></p>
   <p>User Image: <%= @user["image"] %></p>
+  <p>現在の得点: <span id="current-score"><%= @current_score %></span></p>
 </div>
 
 <p className='text-red-800'>じじ</p>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -36,5 +36,3 @@
     <p>ユーザーがログインしていません。</p>
   <% end %>
 </div>
-
-<p className='text-red-800'>じじ</p>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -32,7 +32,11 @@
   <p>User Email: <%= @user["email"] %></p>
   <p>User Nickname: <%= @user["nickname"] %></p>
   <p>User Image: <%= @user["image"] %></p>
-  <p>現在の得点: <span id="current-score"><%= @current_score %></span></p>
+  <% if @user %>
+    <p>現在の得点: <span id="current-score"><%= @current_score %></span></p>
+  <% else %>
+    <p>ユーザーがログインしていません。</p>
+  <% end %>
 </div>
 
 <p className='text-red-800'>じじ</p>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -1,12 +1,12 @@
 <h1 class="font-bold text-2xl text-center pt-24 text-green-100 pb-3">みんなのクイズ一覧</h1>
-<div class="flex flex-wrap">
+<div class="flex flex-wrap justify-center gap-5">
   <% @quizzes.each do |quiz| %>
-    <div class="w-1/2">
+    <div class="w-1/3">
     <%= link_to overview_quiz_path(quiz) do %>
       <% if quiz.image.attached? %>
-        <%= image_tag quiz.image, alt: "milmil", class: "w-1/5" %>
+        <%= image_tag quiz.image, alt: "milmil", class: "w-1/3" %>
       <% else %>
-        <%= image_tag 'quiz02.png', alt: 'default image', class: 'w-1/5' %> <!-- デフォルト画像 -->
+        <%= image_tag 'quiz02.png', alt: 'default image', class: 'w-1/3' %> <!-- デフォルト画像 -->
       <% end %>
       <p><%= quiz.title %></p>
       <p class="text-green-75 pt-12">作成者: <%= quiz.user.name %></p>
@@ -22,8 +22,7 @@
 <%= link_to "新しいクイズを作成する", new_quiz_path, class: "btn btn-primary" %>
 
 <%= button_to 'Logout', 'auth/logout', method: :get, data: { turbo: false } %>
-<%# <%= debug(@user) %>  <!-- @userの内容を表示 -->
-<%# <%= JSON.pretty_generate(@user) %>
+
 
 <div>
   <input type="hidden" id="current-user-id" value="<%= @user['id'] %>"> <!-- ユーザーIDを隠しフィールドに追加 -->

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -19,7 +19,6 @@
     </div>
   <% end %>
 </div>
-
 <%= link_to "新しいクイズを作成する", new_quiz_path, class: "btn btn-primary" %>
 
 <%= button_to 'Logout', 'auth/logout', method: :get, data: { turbo: false } %>

--- a/app/views/quizzes/overview.html.erb
+++ b/app/views/quizzes/overview.html.erb
@@ -8,8 +8,12 @@
 <div class="mt-8">
     <% if @is_owner %>
         <%= link_to "編集する", edit_quiz_path(@quiz), class: "ml-4 text-blue-500 hover:underline" %>
-    <% else%>
-        <%= link_to "開始する", quiz_questions_path(@quiz), class: "bg-blue-500 text-black py-2 px-4 rounded-lg hover:bg-blue-600" %>
+    <% else %>
+        <% if @first_question %>
+            <%= link_to "開始する", quiz_question_path(@quiz, @first_question), class: "bg-blue-500 text-black py-2 px-4 rounded-lg hover:bg-blue-600" %>
+        <% else %>
+            <p>このクイズには設問がありません。</p>
+        <% end %>
     <% end %>
     <%= link_to "戻る", quizzes_path, class: "ml-4 text-blue-500 hover:underline" %>
 </div>

--- a/app/views/quizzes/overview.html.erb
+++ b/app/views/quizzes/overview.html.erb
@@ -8,6 +8,7 @@
 <div class="mt-8">
     <% if @is_owner %>
         <%= link_to "編集する", edit_quiz_path(@quiz), class: "ml-4 text-blue-500 hover:underline" %>
+        <%= link_to "削除する", confirm_destroy_quiz_path(@quiz), method: :get, class: "ml-4 text-red-500 hover:underline", data: { confirm: "本当に削除しますか？" } %>
     <% else %>
         <% if @first_question %>
             <%= link_to "開始する", quiz_question_path(@quiz, @first_question), class: "bg-blue-500 text-black py-2 px-4 rounded-lg hover:bg-blue-600" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,10 +13,15 @@ Rails.application.routes.draw do
   # root "posts#index"
   # root "application#hello"
   resources :quizzes do
-    resources :questions, only: [:index, :edit, :update, :destroy] # クイズに紐づく質問を表示
     member do
       get 'overview'
-      delete :destroy # destroyアクションのルーティング
+    end
+    resources :questions, only: [:index, :create, :edit, :update, :destroy, :show] do
+      member do
+        get 'answer'
+        get 'result'
+        delete :destroy # destroyアクションのルーティング
+      end
     end
   end
   resources :choices

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   end
   resources :choices
   resources :users, only: [:index, :show]
+  resources :user_questions, only: [:create]
 
   get '/auth/auth0/callback' => 'auth0#callback'
   get '/auth/failure' => 'auth0#failure'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,12 @@ Rails.application.routes.draw do
       member do
         get 'answer'
         get 'result'
+        get 'confirm_destroy'
         delete :destroy # destroyアクションのルーティング
       end
+    end
+    member do
+      get 'confirm_destroy' # クイズ削除確認ページ
     end
   end
   resources :choices

--- a/spec/helpers/user_questions_helper_spec.rb
+++ b/spec/helpers/user_questions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UserQuestionsHelper. For example:
+#
+# describe UserQuestionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UserQuestionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/user_questions_spec.rb
+++ b/spec/requests/user_questions_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "UserQuestions", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
# 目的
設問にポイントを付与
設問に解答し、初回で正解ならポイントが加算される
設問とクイズの削除機能（同じブランチ内で勢いでやってしまいました）

# 問題
tailwindが効かない
新規クイズ作成の際にポイントを付与できない

# 仕様
pointsテーブル（新規）pointには10, 20, 30, 40, 50, 60, 70, 80, 90, 100が設定できる
<img width="232" alt="image" src="https://github.com/user-attachments/assets/c6020eb4-76de-47c8-a2a5-a5670c987e5a" />

questionsテーブル（既存）　point_idを追加 各設問が何ポイントかを設定できる
questionsテーブルのpoint_idと、pointsテーブルのidが紐づいている。

user_questionsテーブル（新規）
<img width="284" alt="image" src="https://github.com/user-attachments/assets/7b0cfe95-0e9d-4208-996d-4caa829933d1" />
user_questionsテーブルのuser_idと、usersテーブルのidが紐づいている。
user_questionsテーブルのquiz_idと、quizテーブルのidが紐づいている。
resultは正誤、trueは正解、falseは不正解
is_firstは初回解答かどうか、trueは初回解答、falseは2回目以降解答

ユーザーごとの累計ポイントを算出するために必要。

# 設計方針
ポイント機能
questionsコントローラーにanswerとresultメソッドをつける
answerは解答結果画面を表示
resultは最終結果確認画面を表示

user_questionsコントローラーを追加
createメソッドで、設問に回答する度に、user_questionsテーブルにデータを挿入する
current_scoreメソッドで、現在のユーザーの得点状況を表示


削除機能
編集の際に一部実装していたものを流用。編集ページに削除リンクをつけていたので、それを削除ページとして独立して作成。
confirm_destroy.html.erbを作成
クイズ全体削除と、設問削除のどちらもできるように設定

# 変更内容
設計方針の手順で実装


# レビュー
確認方法
レビューアーが動作確認をすることを想定したヘルプ情報を記述する。
レビュー環境のURL、画面のURL、テストデータの作成方法など

補足情報
レビュアー向けの補足情報があればここに書く。
レビュー観点、重点的に見て欲しい個所、不安な実装個所の相談、注意点、など

チェックリスト
レビューイ
レビュー依頼を出す際にレビューイが満たすべきチェックリスト。
必要に応じて追加、削除しても良い。

 ユニットテストが作成・実施したか？
 UI自動テストを作成・実施したか？
 デザインに影響がある場合にデザイナーにしてもらったか？
クロスブラウザチェック（回答画面以外はSPは不要）を実施したか？
PC
 IE11
 edge最新
 Chrome最新
 Firefox最新
 Safari最新
SP
 Android デフォルトブラウザー4.4.x、Chrome最新
 iOS9.3.5〜
レビューアー
レビュー依頼を受けたレビュアーが満たすべきチェックリスト。
必要に応じて追加、削除しても良い。

 動作確認
 コードレビュー